### PR TITLE
feat: expose `Queue` as a default export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,3 +77,5 @@ export class Queue {
 		}
 	}
 }
+
+export default Queue;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from 'vitest';
 
-import { Queue } from '../src/index';
+import Queue, { Queue as NamedQueue } from '../src/index';
 
 describe(`queue`, () => {
+	test('should expose Queue as a default and named export', () => {
+		expect(Queue).toBe(NamedQueue);
+	});
+
 	test('should add new elements', () => {
 		const queue = new Queue();
 		queue.push('🙃');


### PR DESCRIPTION
Addresses https://github.com/joelvoss/queue-lit/pull/11 and exposes `Queue` as a default export.
We can still consume it as a named export, too.