### PR TITLE
fix: configure Rollup to emit named exports explicitly

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,5 +19,10 @@ export default defineConfig({
 			formats: ['cjs', 'es'],
 			fileName: parse(packageJson.module).name,
 		},
+		rollupOptions: {
+			output: {
+				exports: 'named',
+			},
+		},
 	},
 });


### PR DESCRIPTION
Configured Rollup to emit named exports explicitly in `vite.config.ts`, which matches this package’s intentional mixed API (default plus `Queue`) and removes the `[MIXED_EXPORTS]` warning without changing the public surface.